### PR TITLE
Use spark-defaults.conf and upgrade to 5.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM jupyter/pyspark-notebook:latest
 
-RUN /opt/conda/bin/pip install pathling==5.0.3.dev1
-
 ARG SPARK_SCALA_VERSION=2.12
 
-ENV PYSPARK_SUBMIT_ARGS=" \
-    --packages org.apache.spark:spark-sql-kafka-0-10_${SPARK_SCALA_VERSION}:$APACHE_SPARK_VERSION,au.csiro.pathling:encoders:5.0.3-SNAPSHOT \
-    --repositories https://oss.sonatype.org/content/repositories/snapshots \
-    pyspark-shell"
+USER root
+RUN echo "spark.jars.packages org.apache.spark:spark-sql-kafka-0-10_${SPARK_SCALA_VERSION}:$APACHE_SPARK_VERSION,au.csiro.pathling:encoders:5.1.0" >> /usr/local/spark/conf/spark-defaults.conf
+
+USER ${NB_UID}
+RUN /opt/conda/bin/pip install pathling==5.1.0
 
 # This caches the download of the dependencies specified earlier.
 RUN source /usr/local/bin/before-notebook.d/spark-config.sh && \


### PR DESCRIPTION
I think this is a bit better than using `PYSPARK_SUBMIT_ARGS`, as it actually makes the encoders available more broadly than just pyspark.

This is the approach that I have documented here: https://pathling.csiro.au/docs/encoders#spark-cluster-configuration

I've also updated the version to our newly published package! 🎉